### PR TITLE
Add JarvisLabs Startup Research Grant

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,3 +78,9 @@ The program is open to specialists and professionals in the data science sector 
 ```
 Research Credits Program offers small grants to students conducting research projects outside of formal classes. If you have a research idea that could benefit from a few hundred dollars in support, they invite you to apply through email (earlier by submitting the form). While the program isn’t widely advertised, it provides an opportunity to fund innovative projects. Recipients are kindly asked to acknowledge Together AI in their work.
 ```
+
+[JarvisLabs - Startup Research Grant](https://tally.so/r/WOpRXP)
+
+```
+$500 in GPU compute credits for ML/AI researchers. No faculty status or .edu email required — open to startup researchers, independent labs, and anyone publishing research. 10 grants awarded monthly. GPUs available: A100, H100, H200, RTX 6000 Ada, and more. Per-minute billing with pause/resume.
+```

--- a/README.md
+++ b/README.md
@@ -82,5 +82,5 @@ Research Credits Program offers small grants to students conducting research pro
 [JarvisLabs - Startup Research Grant](https://tally.so/r/WOpRXP)
 
 ```
-$500 in GPU compute credits for ML/AI researchers. No faculty status or .edu email required — open to startup researchers, independent labs, and anyone publishing research. 10 grants awarded monthly. GPUs available: A100, H100, H200, RTX 6000 Ada, and more. Per-minute billing with pause/resume.
+$500 in GPU compute credits for ML/AI researchers. No faculty status or .edu email required — open to startup researchers, independent labs, and anyone publishing research. 10 grants awarded monthly. GPUs available: A100, H100, RTX 6000 Ada, and more. Per-minute billing with pause/resume.
 ```


### PR DESCRIPTION
Adds JarvisLabs Startup Research Grant to the list.

**Program details:**
- $500 in GPU compute credits per grant
- 10 grants awarded monthly
- Open to anyone doing ML/AI research — no faculty status or .edu email required
- GPUs available: A100, H100, H200, RTX 6000 Ada, RTX 5000, A6000, L4
- Per-minute billing with pause/resume (only pay when GPU is running)
- Applications reviewed within a week

**Why it belongs here:** Most GPU grant programs require academic affiliation. This one is specifically designed for startup researchers, independent labs, and self-taught ML engineers who don't qualify for NVIDIA or Google Cloud academic programs.

Application form: https://tally.so/r/WOpRXP